### PR TITLE
Enabled SSL certificate verification

### DIFF
--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -178,8 +178,8 @@ ofHttpResponse ofURLFileLoaderImpl::handleRequest(const ofHttpRequest & request)
 	std::unique_ptr<CURL, void(*)(CURL*)> curl =
 		std::unique_ptr<CURL, void(*)(CURL*)>(curl_easy_init(), curl_easy_cleanup);
 	curl_slist *headers = nullptr;
-	curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, 0);
-	curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 0);
+	curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, true);
+	curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 2);
 	curl_easy_setopt(curl.get(), CURLOPT_URL, request.url.c_str());
 
 	// always follow redirections


### PR DESCRIPTION
Only two lines have been changed here, they should fix the bug referenced in this [report](https://www.huntr.dev/bounties/42325662-6329-4e04-875a-49e2f5d69f78/).
The changes follow the [PHP documentation on CURLOPT_SSL_VERIFYHOST & CURLOPT_SSL_VERIFYPEER](https://www.php.net/manual/en/function.curl-setopt.php).
For some reason, the changes that were made in #6548 did not appear in my fork so I have re-made the initial ``CURLOPT_SSL_VERIFYHOST`` adjustment as part of this commit.